### PR TITLE
#163577779 Feature Get a specific party

### DIFF
--- a/server/src/dummycontroller/PartyController.js
+++ b/server/src/dummycontroller/PartyController.js
@@ -31,6 +31,20 @@ class PartyController {
       data: parties,
     });
   }
+
+  static async getParty(req, res) {
+    const party = models.findOne(req.params.id);
+    if (!party) {
+      return res.status(404).json({
+        status: res.statusCode,
+        error: 'party not found',
+      });
+    }
+    return res.status(200).json({
+      status: res.statusCode,
+      data: party,
+    });
+  }
 }
 
 export default PartyController;

--- a/server/src/models/Party.js
+++ b/server/src/models/Party.js
@@ -37,10 +37,21 @@ class Party {
     }
 
     /**
-     * @returns {object} returns all parties
+     * @returns
+     * @memberof Party
+     * @returns { object } returns all parties
      */
     findAll() {
         return this.parties;
+    }
+
+    /**
+     * @param {uuid} id
+     * @returns { object } returns party details
+     * @memberof Party
+     */
+    findOne(id) {
+        return this.parties.find(party => party.id === id);
     }
 }
 

--- a/server/src/routes/partyRoutes.js
+++ b/server/src/routes/partyRoutes.js
@@ -9,6 +9,7 @@ const validation = [ValidationHandler.validate, ValidationHandler.isEmptyReq];
 
 partyRoutes.post('/', partyValidation.createParty, validation, PartyController.create);
 partyRoutes.get('/', PartyController.getAll);
+partyRoutes.get('/:id', PartyController.getParty);
 
 
 export default partyRoutes;

--- a/server/test/routes/parties/getParties.js
+++ b/server/test/routes/parties/getParties.js
@@ -2,6 +2,9 @@ import request from 'supertest';
 import { expect } from 'chai';
 import app from '../../../src/app';
 
+const validID = 'fb097bde-5959-45ff-8e21-51184fa60c25';
+const invalidID = 'fb097bde-5959-45ff-8e21-51184fa60c';
+
 describe('Parties route:', () => {
     it('should get all parties', (done) => {
         request(app)
@@ -9,6 +12,30 @@ describe('Parties route:', () => {
             .end((err, res) => {
                 expect(res.statusCode).to.equal(200);
                 expect(res.body.data).to.be.a('array');
+
+            done(err);
+            });
+    });
+
+    it('should get parties by a valid ID', (done) => {
+        request(app)
+            .get(`/api/v1/parties/${validID}`)
+            .end((err, res) => {
+                expect(res.statusCode).to.equal(200);
+                expect(res.body).to.be.a('object');
+                expect(res.body).to.include.keys('data');
+
+            done(err);
+            });
+    });
+
+    it('should return errors for invalid ID', (done) => {
+        request(app)
+            .get(`/api/v1/parties/${invalidID}`)
+            .end((err, res) => {
+                expect(res.statusCode).to.equal(404);
+                expect(res.body).to.include.keys('error');
+                expect(res.body.error).to.equal('party not found');
 
             done(err);
             });


### PR DESCRIPTION
#### What does this PR do?
This pull request adds the endpoint for the user, to get the party with a specific ID

#### Description of Task to be completed?
When the user sends a GET request to the endpoint /api/v1/parties/:id

The user should be able to by default see the party with that unique ID
#### How should this be manually tested?
Please check the README

#### What are the relevant pivotal tracker stories?
#16357779

#### Any background context you want to add?
N/A

#### Screenshots
N/A