### PR TITLE
#163578915 Feature Update Party name

### DIFF
--- a/server/src/dummycontroller/PartyController.js
+++ b/server/src/dummycontroller/PartyController.js
@@ -45,6 +45,22 @@ class PartyController {
       data: party,
     });
   }
+
+  static async update(req, res) {
+    const party = models.findOne(req.params.id);
+    if (!party) {
+      return res.status(404).json({
+        status: res.statusCode,
+        error: 'party not found',
+      });
+    }
+
+    const updatedParty = models.update(req.params.id, req.body);
+    return res.status(200).json({
+      status: res.statusCode,
+      data: updatedParty,
+    });
+  }
 }
 
 export default PartyController;

--- a/server/src/models/Party.js
+++ b/server/src/models/Party.js
@@ -2,6 +2,8 @@ import moment from 'moment';
 import uuidv4 from 'uuid/v4';
 import partyData from '../../data/party';
 
+let formatedDate = moment().format('YYYY-MM-DDTHH:mm:ss.SSS');
+
 /**
  * @exports
  * @class Party
@@ -28,8 +30,8 @@ class Party {
             fullname: data.fullname,
             hqAddress: data.hqAddress,
             logoUrl: data.logoUrl,
-            createdAt: moment.now(),
-            updatedAt: moment.now(),
+            createdAt: formatedDate,
+            updatedAt: formatedDate,
         }
         
         this.parties.push(newParty);
@@ -52,6 +54,18 @@ class Party {
      */
     findOne(id) {
         return this.parties.find(party => party.id === id);
+    }
+    /**
+     * @param { uuid } id
+     * @param { object } data
+     * @memberof Party
+     */
+    update(id, data) {
+        const party = this.findOne(id);
+        const index = this.parties.indexOf(party);
+        this.parties[index].name = data["name"] || party.name;
+        this.parties[index].updatedAt = formatedDate;
+        return this.parties[index];
     }
 }
 

--- a/server/src/routes/partyRoutes.js
+++ b/server/src/routes/partyRoutes.js
@@ -10,6 +10,7 @@ const validation = [ValidationHandler.validate, ValidationHandler.isEmptyReq];
 partyRoutes.post('/', partyValidation.createParty, validation, PartyController.create);
 partyRoutes.get('/', PartyController.getAll);
 partyRoutes.get('/:id', PartyController.getParty);
+partyRoutes.put('/:id/name', partyValidation.update, validation, PartyController.update);
 
 
 export default partyRoutes;

--- a/server/src/routes/partyRoutes.js
+++ b/server/src/routes/partyRoutes.js
@@ -10,7 +10,7 @@ const validation = [ValidationHandler.validate, ValidationHandler.isEmptyReq];
 partyRoutes.post('/', partyValidation.createParty, validation, PartyController.create);
 partyRoutes.get('/', PartyController.getAll);
 partyRoutes.get('/:id', PartyController.getParty);
-partyRoutes.put('/:id/name', partyValidation.update, validation, PartyController.update);
+partyRoutes.patch('/:id/name', partyValidation.update, validation, PartyController.update);
 
 
 export default partyRoutes;

--- a/server/src/validations/partyValidation.js
+++ b/server/src/validations/partyValidation.js
@@ -16,4 +16,8 @@ export default {
       .exists().withMessage('Logo URL must be specified')
       .custom(value => notEmpty(value, 'Logo URL field cannot be left blank')),
   ],
+  update: [
+    check('name')
+      .custom(value => notEmpty(value, 'Name field cannot be left blank')),
+  ],
 };

--- a/server/test/routes/parties/updateParty.js
+++ b/server/test/routes/parties/updateParty.js
@@ -1,0 +1,34 @@
+import request from 'supertest';
+import { expect } from 'chai';
+import app from '../../../src/app';
+
+const validID = 'fb097bde-5959-45ff-8e21-51184fa60c25';
+const invalidID = 'fb097bde-5959-45ff-8e21-51184fa60c';
+
+describe('Party\'s Route: Update parties name', () => {
+    it('should change the name of given party', (done) => {
+        request(app)
+            .put(`/api/v1/parties/${validID}/name`)
+            .set('Accept', 'application/json')
+            .send({ name: 'PDP' })
+            .end((err, res) => {
+                expect(res.statusCode).to.equal(200);
+                expect(res.body).to.be.a('object');
+
+            done(err);
+            })
+    });
+
+    it('should output error for invalid party ID', (done) => {
+        request(app)
+            .put(`/api/v1/parties/${invalidID}/name`)
+            .set('Accept', 'application/json')
+            .send({ name: 'PDP' })
+            .end((err, res) => {
+                expect(res.statusCode).to.equal(404);
+                expect(res.body).to.include.keys('error');
+
+            done(err);
+            })
+    })
+})

--- a/server/test/routes/parties/updateParty.js
+++ b/server/test/routes/parties/updateParty.js
@@ -14,6 +14,7 @@ describe('Party\'s Route: Update parties name', () => {
             .end((err, res) => {
                 expect(res.statusCode).to.equal(200);
                 expect(res.body).to.be.a('object');
+                expect(res.body.data).to.include.keys('name');
 
             done(err);
             })
@@ -21,7 +22,7 @@ describe('Party\'s Route: Update parties name', () => {
 
     it('should output error for invalid party ID', (done) => {
         request(app)
-            .put(`/api/v1/parties/${invalidID}/name`)
+            .patch(`/api/v1/parties/${invalidID}/name`)
             .set('Accept', 'application/json')
             .send({ name: 'PDP' })
             .end((err, res) => {


### PR DESCRIPTION
#### What does this PR do?
This pull request adds the endpoint for the user, to update the party's name with a specific ID

#### Description of Task to be completed?
When the user sends a PATCH request to the endpoint /api/v1/parties/:id/name

The user should be able to by default see the party details with that unique ID

#### How should this be manually tested?
Navigate to the /api/v1/parties/:id/name with Postman

#### What are the relevant pivotal tracker stories?
#163578915

#### Any background context you want to add?
N/A

#### Screenshots
N/A