### PR TITLE
#164290521 Feature get table count details

### DIFF
--- a/server/src/controllers/UserController.js
+++ b/server/src/controllers/UserController.js
@@ -3,6 +3,7 @@ import { config } from 'dotenv';
 import bcrypt from 'bcrypt';
 import Mailer from '../utils/Mailer';
 import models from '../models/users';
+import db from '../models/index';
 import Authorization from '../middlewares/Authorization';
 
 config();
@@ -162,6 +163,24 @@ class UserController {
       is_admin: data.is_admin,
       password: data.password,
     };
+  }
+
+  static async details(req, res) {
+    try {
+      const query = `SELECT(SELECT COUNT(*) FROM users) as users,
+        (SELECT COUNT(*) FROM offices) as offices,
+        (SELECT COUNT(*) FROM parties) as parties`;
+      const { rows } = await db.query(query);
+      return res.status(200).json({
+        status: 200,
+        data: rows[0],
+      });
+    } catch (error) {
+      return res.status(500).json({
+        status: 500,
+        error,
+      });
+    }
   }
 }
 

--- a/server/src/routes/users.js
+++ b/server/src/routes/users.js
@@ -34,5 +34,6 @@ userRoutes.post('/signup', UserValidation.signup, validation, UserController.sig
 userRoutes.post('/login', UserValidation.login, validation, UserController.login);
 userRoutes.post('/forgot_password', UserValidation.forgotPassword, validation, UserController.forgotPassword);
 userRoutes.patch('/user', Authorization.authenticate, upload.single('avatar'), UserController.user);
+userRoutes.get('/details', Authorization.authenticate, Authorization.isAdmin, UserController.details);
 
 export default userRoutes;

--- a/server/test/routes/petition.js
+++ b/server/test/routes/petition.js
@@ -105,3 +105,43 @@ describe('Petition', () => {
     });
   });
 });
+
+describe('## Table details', () => {
+  it('should return count of tables', (done) => {
+    request(app)
+      .get('/api/v1/auth/details')
+      .set('authorization', adminToken)
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+        expect(res.body).to.include.keys('data');
+        expect(res.body.data).to.include.keys('users');
+        expect(res.body.data).to.include.keys('offices');
+        expect(res.body.data).to.include.keys('parties');
+
+        done(err);
+      });
+  });
+
+  it('should return error for forbidden access', (done) => {
+    request(app)
+      .get('/api/v1/auth/details')
+      .set('authorization', userToken)
+      .end((err, res) => {
+        expect(res.status).to.equal(403);
+        expect(res.body).to.include.keys('message');
+
+        done(err);
+      });
+  });
+
+  it('should return error for unauthorized access', (done) => {
+    request(app)
+      .get('/api/v1/auth/details')
+      .end((err, res) => {
+        expect(res.status).to.equal(401);
+        expect(res.body).to.include.keys('error');
+
+        done(err);
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
This PR adds a new endpoint to get tables count
#### Description of Task to be completed?
#### How should this be manually tested?
Navigate to the endpoint `/api/v1/auth/details` with Postman with an admin token
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
#164290521
#### Screenshots (if appropriate)
#### Questions: